### PR TITLE
Implement KMS API with RSA signature verification and AES session key…

### DIFF
--- a/backend/app/api/routes/kms.py
+++ b/backend/app/api/routes/kms.py
@@ -1,0 +1,74 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from datetime import datetime, timedelta
+import base64, time, os
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from core.crypto import encrypt_with_rsa
+
+router = APIRouter()
+
+# 模擬使用者資料庫（最終會改為資料庫查詢）
+USER_KEYS = {
+    "alice": {
+        "public_key_pem": open("alice_pub.pem", "rb").read(),
+    }
+}
+
+# 模擬 session key 暫存（正式版可用 Redis 或資料庫）
+SESSION_KEYS = {}  # username: {"key": b"...", "expires_at": timestamp}
+
+class KeyRequest(BaseModel):
+    username: str
+    timestamp: int
+    signature_b64: str
+
+@router.post("/kms/request-key")
+def request_session_key(data: KeyRequest):
+    now = int(time.time())
+    if abs(now - data.timestamp) > 60:
+        raise HTTPException(status_code=400, detail="Timestamp too old or invalid")
+
+    user = USER_KEYS.get(data.username)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    public_key = serialization.load_pem_public_key(user["public_key_pem"])
+    message = f"{data.username}:{data.timestamp}".encode()
+    signature = base64.b64decode(data.signature_b64)
+
+    try:
+        public_key.verify(
+            signature,
+            message,
+            padding.PKCS1v15(),
+            hashes.SHA256()
+        )
+    except Exception:
+        raise HTTPException(status_code=403, detail="Signature verification failed")
+
+    # 若已有尚未過期的 session key，直接回傳
+    cached = SESSION_KEYS.get(data.username)
+    if cached and cached["expires_at"] > now:
+        encrypted = encrypt_with_rsa(public_key, cached["key"])
+        return {
+            "session_key_encrypted": base64.b64encode(encrypted).decode(),
+            "expires_in": cached["expires_at"] - now
+        }
+
+    # 產生新的 AES session key
+    session_key = AESGCM.generate_key(bit_length=256)
+    expires_at = now + 600
+    SESSION_KEYS[data.username] = {
+        "key": session_key,
+        "expires_at": expires_at
+    }
+
+    encrypted_key = encrypt_with_rsa(public_key, session_key)
+    return {
+        "session_key_encrypted": base64.b64encode(encrypted_key).decode(),
+        "expires_in": 600
+    }

--- a/backend/app/api/routes/kms.py
+++ b/backend/app/api/routes/kms.py
@@ -1,30 +1,26 @@
+import base64
+import time
+from datetime import datetime, timedelta
+
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
-from datetime import datetime, timedelta
-import base64, time, os
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
-from cryptography.hazmat.primitives.asymmetric import rsa
+from sqlmodel import Session, select
 
+from app.models import User, SessionKey
+from app.db.session import engine
 from core.crypto import encrypt_with_rsa
 
 router = APIRouter()
 
-# 模擬使用者資料庫（最終會改為資料庫查詢）
-USER_KEYS = {
-    "alice": {
-        "public_key_pem": open("alice_pub.pem", "rb").read(),
-    }
-}
-
-# 模擬 session key 暫存（正式版可用 Redis 或資料庫）
-SESSION_KEYS = {}  # username: {"key": b"...", "expires_at": timestamp}
 
 class KeyRequest(BaseModel):
-    username: str
+    username: str  # 實際上會對應到 User.email
     timestamp: int
     signature_b64: str
+
 
 @router.post("/kms/request-key")
 def request_session_key(data: KeyRequest):
@@ -32,43 +28,63 @@ def request_session_key(data: KeyRequest):
     if abs(now - data.timestamp) > 60:
         raise HTTPException(status_code=400, detail="Timestamp too old or invalid")
 
-    user = USER_KEYS.get(data.username)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not found")
+    with Session(engine) as session:
+        # 查詢對應使用者
+        user = session.exec(select(User).where(User.email == data.username)).first()
+        if not user or not user.public_key:
+            raise HTTPException(status_code=404, detail="User not found or missing public key")
 
-    public_key = serialization.load_pem_public_key(user["public_key_pem"])
-    message = f"{data.username}:{data.timestamp}".encode()
-    signature = base64.b64decode(data.signature_b64)
+        # 解析使用者公鑰（PEM 格式字串）
+        try:
+            public_key = serialization.load_pem_public_key(user.public_key.encode())
+        except Exception:
+            raise HTTPException(status_code=500, detail="Invalid public key format")
 
-    try:
-        public_key.verify(
-            signature,
-            message,
-            padding.PKCS1v15(),
-            hashes.SHA256()
+        # 驗證簽章
+        message = f"{data.username}:{data.timestamp}".encode()
+        signature = base64.b64decode(data.signature_b64)
+
+        try:
+            public_key.verify(
+                signature,
+                message,
+                padding.PKCS1v15(),
+                hashes.SHA256()
+            )
+        except Exception:
+            raise HTTPException(status_code=403, detail="Signature verification failed")
+
+        # 查詢是否已有未過期的 SessionKey
+        existing_key = session.exec(
+            select(SessionKey)
+            .where(SessionKey.user_id == user.id)
+            .where(SessionKey.expires_at > datetime.utcnow())
+        ).first()
+
+        if existing_key:
+            return {
+                "session_key_encrypted": existing_key.session_key_encrypted,
+                "expires_in": int((existing_key.expires_at - datetime.utcnow()).total_seconds())
+            }
+
+        # 產生新的 AES session key
+        session_key = AESGCM.generate_key(bit_length=256)
+        expires_at = datetime.utcnow() + timedelta(minutes=10)
+
+        # 使用公鑰加密 session key
+        encrypted_key = encrypt_with_rsa(public_key, session_key)
+        encrypted_key_b64 = base64.b64encode(encrypted_key).decode()
+
+        # 儲存 SessionKey 到資料庫
+        new_key = SessionKey(
+            user_id=user.id,
+            session_key_encrypted=encrypted_key_b64,
+            expires_at=expires_at
         )
-    except Exception:
-        raise HTTPException(status_code=403, detail="Signature verification failed")
+        session.add(new_key)
+        session.commit()
 
-    # 若已有尚未過期的 session key，直接回傳
-    cached = SESSION_KEYS.get(data.username)
-    if cached and cached["expires_at"] > now:
-        encrypted = encrypt_with_rsa(public_key, cached["key"])
         return {
-            "session_key_encrypted": base64.b64encode(encrypted).decode(),
-            "expires_in": cached["expires_at"] - now
+            "session_key_encrypted": encrypted_key_b64,
+            "expires_in": 600
         }
-
-    # 產生新的 AES session key
-    session_key = AESGCM.generate_key(bit_length=256)
-    expires_at = now + 600
-    SESSION_KEYS[data.username] = {
-        "key": session_key,
-        "expires_at": expires_at
-    }
-
-    encrypted_key = encrypt_with_rsa(public_key, session_key)
-    return {
-        "session_key_encrypted": base64.b64encode(encrypted_key).decode(),
-        "expires_in": 600
-    }


### PR DESCRIPTION
This pull request implements the `/kms/request-key` API endpoint.

Features included:
- RSA signature verification using the user's public key (username + timestamp)
- AES-GCM 256-bit session key generation
- Public key encryption of session key before sending it back (RSA-OAEP)
- In-memory session key caching with 10-minute expiration
- Code is modularized with `encrypt_with_rsa()` logic in `core/crypto.py`

Note:
- Public key is currently loaded from a mock dictionary (USER_KEYS)
- Session key storage is temporary (will be migrated to DB in task 4)